### PR TITLE
Add indexed db

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -65,6 +65,7 @@ jobs:
             const lint = '${{ steps.lint.outcome }}';
             const test = '${{ steps.test.outcome }}';
             const build = '${{ steps.build.outcome }}';
+            const marker = '<!-- pr-check-results -->';
 
             const icon = (outcome) => {
               if (outcome === 'success') return '✅';
@@ -74,6 +75,7 @@ jobs:
             };
 
             const body = [
+              marker,
               '## PR Check Results',
               '',
               '| Step | Result |',
@@ -83,12 +85,31 @@ jobs:
               `| Build | ${icon(build)} \`${build}\` |`,
             ].join('\n');
 
-            await github.rest.issues.createComment({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body,
             });
+
+            const previousComment = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker)
+            );
+
+            if (previousComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previousComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
 
       - name: Fail if any check failed
         if: ${{ always() }}

--- a/src/components/root/editor/autobuild/Autobuild.tsx
+++ b/src/components/root/editor/autobuild/Autobuild.tsx
@@ -61,7 +61,7 @@ function Autobuild() {
     "generation-cache",
   );
 
-  const [cache, setCache] = useSessionStorage<{
+  const [cacheMetadata, setCacheMetadata] = useSessionStorage<{
     schedulesCacheKey: string | null;
     lastScrolledIndex: number;
   }>(
@@ -96,13 +96,13 @@ function Autobuild() {
   >(null);
 
   useEffect(() => {
-    if ("schedule" in cache) {
-      setCache({
-        schedulesCacheKey: cache.schedulesCacheKey ?? null,
-        lastScrolledIndex: cache.lastScrolledIndex,
+    if ("schedule" in cacheMetadata) {
+      setCacheMetadata({
+        schedulesCacheKey: cacheMetadata.schedulesCacheKey ?? null,
+        lastScrolledIndex: cacheMetadata.lastScrolledIndex,
       });
     }
-  }, [cache, setCache]);
+  }, [cacheMetadata, setCacheMetadata]);
 
   const sections = useSearch({
     from: "/editor/autobuild",
@@ -127,7 +127,7 @@ function Autobuild() {
 
     setGeneratedSchedules(null);
     schedulesCacheKeyRef.current = null;
-    setCache((c) => ({
+    setCacheMetadata((c) => ({
       lastScrolledIndex: c.lastScrolledIndex,
       schedulesCacheKey: null,
     }));
@@ -136,16 +136,16 @@ function Autobuild() {
     if (schedulesCacheKey != null) {
       void deleteGeneratedSchedulesCache(schedulesCacheKey);
     }
-  }, [setCache]);
+  }, [setCacheMetadata]);
 
   const onScroll = useCallback(
     (start: number) => {
-      setCache((c) => ({
+      setCacheMetadata((c) => ({
         schedulesCacheKey: c.schedulesCacheKey,
         lastScrolledIndex: start,
       }));
     },
-    [setCache],
+    [setCacheMetadata],
   );
 
   useEffect(() => {
@@ -155,7 +155,7 @@ function Autobuild() {
 
       schedulesCacheKeyRef.current = nextSchedulesCacheKey;
       setGeneratedSchedules(e.schedules);
-      setCache((c) => ({
+      setCacheMetadata((c) => ({
         lastScrolledIndex: c.lastScrolledIndex,
         schedulesCacheKey: nextSchedulesCacheKey,
       }));
@@ -171,7 +171,7 @@ function Autobuild() {
             schedulesCacheKeyRef.current === nextSchedulesCacheKey
           ) {
             schedulesCacheKeyRef.current = null;
-            setCache((c) => ({
+            setCacheMetadata((c) => ({
               lastScrolledIndex: c.lastScrolledIndex,
               schedulesCacheKey: null,
             }));
@@ -183,7 +183,7 @@ function Autobuild() {
     return () => {
       unsub();
     };
-  }, [setCache]);
+  }, [setCacheMetadata]);
 
   return (
     <div className="relative box-border flex h-full w-full flex-col items-center gap-2 overflow-x-hidden overflow-y-auto p-2">

--- a/src/components/root/editor/autobuild/Autobuild.tsx
+++ b/src/components/root/editor/autobuild/Autobuild.tsx
@@ -95,15 +95,6 @@ function Autobuild() {
     SavedSection[][] | null
   >(null);
 
-  useEffect(() => {
-    if ("schedule" in cacheMetadata) {
-      setCacheMetadata({
-        schedulesCacheKey: cacheMetadata.schedulesCacheKey ?? null,
-        lastScrolledIndex: cacheMetadata.lastScrolledIndex,
-      });
-    }
-  }, [cacheMetadata, setCacheMetadata]);
-
   const sections = useSearch({
     from: "/editor/autobuild",
     select: (s) => s.sections,

--- a/src/components/root/editor/autobuild/Autobuild.tsx
+++ b/src/components/root/editor/autobuild/Autobuild.tsx
@@ -154,7 +154,10 @@ function Autobuild() {
       }));
 
       if (previousSchedulesCacheKey !== null) {
-        void deleteGeneratedSchedulesCache(previousSchedulesCacheKey);
+        void deleteGeneratedSchedulesCache(
+          previousSchedulesCacheKey,
+          abortController.signal,
+        );
       }
 
       void setGeneratedSchedulesCache(

--- a/src/components/root/editor/autobuild/Autobuild.tsx
+++ b/src/components/root/editor/autobuild/Autobuild.tsx
@@ -4,12 +4,28 @@ import { Checkbox } from "src/components/ui/checkbox";
 import { Field, FieldGroup, FieldLabel } from "src/components/ui/field";
 import { Input } from "src/components/ui/input";
 import { useSessionStorage } from "src/hooks";
+import {
+  deleteGeneratedSchedulesCache,
+  getGeneratedSchedulesCache,
+  setGeneratedSchedulesCache,
+} from "src/lib/store/db";
 import { onWorkerMessage, postWorkerMessage } from "src/lib/store/worker";
 import type { Code } from "src/types/autobuild";
 import type { SavedSection } from "src/types/schedule";
 import { Button, PageLoading } from "@/components";
 import CodesForm from "./CodesForm";
 import Results from "./Results";
+
+const GENERATED_SCHEDULES_CACHE_KEY = "latest-autobuild";
+
+function createGeneratedSchedulesCacheKey() {
+  const id =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+  return `${GENERATED_SCHEDULES_CACHE_KEY}-${id}`;
+}
 
 type BulidingState =
   | {
@@ -24,6 +40,7 @@ type BulidingState =
 
 function Autobuild() {
   const initialScroll = useRef<number>(0);
+  const schedulesCacheKeyRef = useRef<string | null>(null);
 
   const [buildingState, setBuildingState] = useState<BulidingState>({
     type: "initial-load",
@@ -45,19 +62,47 @@ function Autobuild() {
   );
 
   const [cache, setCache] = useSessionStorage<{
-    schedules: SavedSection[][] | null;
+    schedulesCacheKey: string | null;
     lastScrolledIndex: number;
   }>(
     {
-      schedules: null,
+      schedulesCacheKey: null,
       lastScrolledIndex: 0,
     },
     "cache",
     (c) => {
       initialScroll.current = c.lastScrolledIndex;
-      setBuildingState({ type: "form" });
+      schedulesCacheKeyRef.current = c.schedulesCacheKey ?? null;
+
+      if (c.schedulesCacheKey == null) {
+        setBuildingState({ type: "form" });
+        return;
+      }
+
+      void getGeneratedSchedulesCache(c.schedulesCacheKey).then(
+        (cachedSchedules) => {
+          if (cachedSchedules !== null) {
+            setGeneratedSchedules(cachedSchedules);
+          }
+
+          setBuildingState({ type: "form" });
+        },
+      );
     },
   );
+
+  const [generatedSchedules, setGeneratedSchedules] = useState<
+    SavedSection[][] | null
+  >(null);
+
+  useEffect(() => {
+    if ("schedule" in cache) {
+      setCache({
+        schedulesCacheKey: cache.schedulesCacheKey ?? null,
+        lastScrolledIndex: cache.lastScrolledIndex,
+      });
+    }
+  }, [cache, setCache]);
 
   const sections = useSearch({
     from: "/editor/autobuild",
@@ -78,17 +123,25 @@ function Autobuild() {
   );
 
   const onReturn = useCallback(() => {
+    const schedulesCacheKey = schedulesCacheKeyRef.current;
+
+    setGeneratedSchedules(null);
+    schedulesCacheKeyRef.current = null;
     setCache((c) => ({
-      ...c,
-      schedules: null,
+      lastScrolledIndex: c.lastScrolledIndex,
+      schedulesCacheKey: null,
     }));
     setBuildingState({ type: "form" });
+
+    if (schedulesCacheKey != null) {
+      void deleteGeneratedSchedulesCache(schedulesCacheKey);
+    }
   }, [setCache]);
 
   const onScroll = useCallback(
     (start: number) => {
       setCache((c) => ({
-        ...c,
+        schedulesCacheKey: c.schedulesCacheKey,
         lastScrolledIndex: start,
       }));
     },
@@ -97,10 +150,34 @@ function Autobuild() {
 
   useEffect(() => {
     const unsub = onWorkerMessage("generate", (e) => {
+      const previousSchedulesCacheKey = schedulesCacheKeyRef.current;
+      const nextSchedulesCacheKey = createGeneratedSchedulesCacheKey();
+
+      schedulesCacheKeyRef.current = nextSchedulesCacheKey;
+      setGeneratedSchedules(e.schedules);
       setCache((c) => ({
-        ...c,
-        schedules: e.schedules,
+        lastScrolledIndex: c.lastScrolledIndex,
+        schedulesCacheKey: nextSchedulesCacheKey,
       }));
+
+      if (previousSchedulesCacheKey !== null) {
+        void deleteGeneratedSchedulesCache(previousSchedulesCacheKey);
+      }
+
+      void setGeneratedSchedulesCache(nextSchedulesCacheKey, e.schedules).then(
+        (success) => {
+          if (
+            !success &&
+            schedulesCacheKeyRef.current === nextSchedulesCacheKey
+          ) {
+            schedulesCacheKeyRef.current = null;
+            setCache((c) => ({
+              lastScrolledIndex: c.lastScrolledIndex,
+              schedulesCacheKey: null,
+            }));
+          }
+        },
+      );
     });
 
     return () => {
@@ -110,7 +187,7 @@ function Autobuild() {
 
   return (
     <div className="relative box-border flex h-full w-full flex-col items-center gap-2 overflow-x-hidden overflow-y-auto p-2">
-      {cache.schedules === null ? (
+      {generatedSchedules === null ? (
         <>
           {buildingState.type === "form" && (
             <>
@@ -227,11 +304,12 @@ function Autobuild() {
               </div>
             </>
           )}
+          {buildingState.type === "initial-load" && <PageLoading />}
           {buildingState.type === "building" && <PageLoading />}
         </>
       ) : (
         <Results
-          generatedSchedules={cache.schedules}
+          generatedSchedules={generatedSchedules}
           onReturn={onReturn}
           onScroll={onScroll}
           initialScroll={initialScroll.current}

--- a/src/components/root/editor/autobuild/Autobuild.tsx
+++ b/src/components/root/editor/autobuild/Autobuild.tsx
@@ -27,7 +27,7 @@ function createGeneratedSchedulesCacheKey() {
   return `${GENERATED_SCHEDULES_CACHE_KEY}-${id}`;
 }
 
-type BulidingState =
+type BuildingState =
   | {
       type: "initial-load";
     }
@@ -42,7 +42,7 @@ function Autobuild() {
   const initialScroll = useRef<number>(0);
   const schedulesCacheKeyRef = useRef<string | null>(null);
 
-  const [buildingState, setBuildingState] = useState<BulidingState>({
+  const [buildingState, setBuildingState] = useState<BuildingState>({
     type: "initial-load",
   });
 

--- a/src/components/root/editor/autobuild/Autobuild.tsx
+++ b/src/components/root/editor/autobuild/Autobuild.tsx
@@ -140,6 +140,8 @@ function Autobuild() {
   );
 
   useEffect(() => {
+    const abortController = new AbortController();
+
     const unsub = onWorkerMessage("generate", (e) => {
       const previousSchedulesCacheKey = schedulesCacheKeyRef.current;
       const nextSchedulesCacheKey = createGeneratedSchedulesCacheKey();
@@ -155,23 +157,26 @@ function Autobuild() {
         void deleteGeneratedSchedulesCache(previousSchedulesCacheKey);
       }
 
-      void setGeneratedSchedulesCache(nextSchedulesCacheKey, e.schedules).then(
-        (success) => {
-          if (
-            !success &&
-            schedulesCacheKeyRef.current === nextSchedulesCacheKey
-          ) {
-            schedulesCacheKeyRef.current = null;
-            setCacheMetadata((c) => ({
-              lastScrolledIndex: c.lastScrolledIndex,
-              schedulesCacheKey: null,
-            }));
-          }
-        },
-      );
+      void setGeneratedSchedulesCache(
+        nextSchedulesCacheKey,
+        e.schedules,
+        abortController.signal,
+      ).then((success) => {
+        if (
+          !success &&
+          schedulesCacheKeyRef.current === nextSchedulesCacheKey
+        ) {
+          schedulesCacheKeyRef.current = null;
+          setCacheMetadata((c) => ({
+            lastScrolledIndex: c.lastScrolledIndex,
+            schedulesCacheKey: null,
+          }));
+        }
+      });
     });
 
     return () => {
+      abortController.abort();
       unsub();
     };
   }, [setCacheMetadata]);

--- a/src/components/root/editor/autobuild/Results.tsx
+++ b/src/components/root/editor/autobuild/Results.tsx
@@ -11,7 +11,7 @@ const Footer = memo((props: { returnFn: () => void }) => {
 
   return (
     <div className="bg-background">
-      <Button variant="special" className="w-fit" onClick={() => returnFn()}>
+      <Button variant="special" className="w-fit" onClick={returnFn}>
         Return
       </Button>
     </div>

--- a/src/components/root/editor/autobuild/Results.tsx
+++ b/src/components/root/editor/autobuild/Results.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "@tanstack/react-router";
 import { memo, useCallback, useMemo } from "react";
-import { Virtuoso } from "react-virtuoso";
+import { type Components, Virtuoso } from "react-virtuoso";
 import Button from "src/components/Button";
 import { cn } from "src/lib/utils";
 import type { SavedSection } from "src/types/schedule";
@@ -55,11 +55,19 @@ type Props = {
 
 export default memo(
   ({ generatedSchedules, onReturn, onScroll, initialScroll }: Props) => {
-    const components = useMemo(
+    const components: Components<
+      {
+        sectionId: number;
+        colorIndex: number;
+      }[]
+    > = useMemo(
       () => ({
         EmptyPlaceholder: () => <NoResult />,
+        Header: () => (
+          <div>{generatedSchedules.length} schedules generated</div>
+        ),
       }),
-      [],
+      [generatedSchedules.length],
     );
 
     return (

--- a/src/lib/store/db.ts
+++ b/src/lib/store/db.ts
@@ -8,27 +8,35 @@ export async function getDb() {
     return;
   }
 
+  if (db !== null) {
+    return db;
+  }
+
   const req = indexedDB.open("asf");
 
-  const promise: Promise<IDBDatabase | null> = new Promise(
-    (resolve, reject) => {
-      const t = setTimeout(() => resolve(null), 1000);
+  const promise: Promise<IDBDatabase | null> = new Promise((resolve) => {
+    const t = setTimeout(() => {
+      console.error("Opening database timed out");
+      resolve(null);
+    }, 1000);
 
-      req.onsuccess = () => {
-        clearTimeout(t);
-        resolve(req.result);
-      };
+    req.onsuccess = () => {
+      clearTimeout(t);
+      resolve(req.result);
+    };
 
-      req.onerror = () => {
-        clearTimeout(t);
-        reject();
-      };
-    },
-  );
+    req.onerror = () => {
+      clearTimeout(t);
+      console.error("Could not open database");
+      resolve(null);
+    };
+  });
 
   const r = await promise.catch(() => null);
 
   if (r !== null) {
     db = r;
   }
+
+  return db;
 }

--- a/src/lib/store/db.ts
+++ b/src/lib/store/db.ts
@@ -110,6 +110,7 @@ export async function getGeneratedSchedulesCache(key: string) {
 export async function setGeneratedSchedulesCache(
   key: string,
   schedules: SavedSection[][],
+  abortSignal?: AbortSignal,
 ) {
   const database = await getDb();
 
@@ -125,6 +126,10 @@ export async function setGeneratedSchedulesCache(
 
   return new Promise<boolean>((resolve) => {
     const transaction = store.transaction;
+
+    if (abortSignal) {
+      abortSignal.onabort = () => transaction.abort();
+    }
 
     store.put({
       key,
@@ -146,7 +151,10 @@ export async function setGeneratedSchedulesCache(
   });
 }
 
-export async function deleteGeneratedSchedulesCache(key: string) {
+export async function deleteGeneratedSchedulesCache(
+  key: string,
+  abortSignal?: AbortSignal,
+) {
   const database = await getDb();
 
   if (!database) {
@@ -161,6 +169,10 @@ export async function deleteGeneratedSchedulesCache(key: string) {
 
   return new Promise<boolean>((resolve) => {
     const transaction = store.transaction;
+
+    if (abortSignal) {
+      abortSignal.onabort = () => transaction.abort();
+    }
 
     store.delete(key);
 

--- a/src/lib/store/db.ts
+++ b/src/lib/store/db.ts
@@ -1,6 +1,6 @@
 import type { SavedSection } from "src/types/schedule";
 
-const DB_NAME = "asf";
+const DB_NAME = "schedule-maker";
 const DB_VERSION = 2;
 const GENERATED_SCHEDULES_CACHE_STORE = "generated-schedules-cache";
 
@@ -59,7 +59,7 @@ export async function getDb() {
     };
   });
 
-  db = await openingDb.catch(() => null);
+  db = await openingDb;
   openingDb = null;
 
   return db;

--- a/src/lib/store/db.ts
+++ b/src/lib/store/db.ts
@@ -1,0 +1,34 @@
+let db: IDBDatabase | null = null;
+
+/**
+ * Get connection to the local database
+ * */
+export async function getDb() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const req = indexedDB.open("asf");
+
+  const promise: Promise<IDBDatabase | null> = new Promise(
+    (resolve, reject) => {
+      const t = setTimeout(() => resolve(null), 1000);
+
+      req.onsuccess = () => {
+        clearTimeout(t);
+        resolve(req.result);
+      };
+
+      req.onerror = () => {
+        clearTimeout(t);
+        reject();
+      };
+    },
+  );
+
+  const r = await promise.catch(() => null);
+
+  if (r !== null) {
+    db = r;
+  }
+}

--- a/src/lib/store/db.ts
+++ b/src/lib/store/db.ts
@@ -1,10 +1,23 @@
+import type { SavedSection } from "src/types/schedule";
+
+const DB_NAME = "asf";
+const DB_VERSION = 2;
+const GENERATED_SCHEDULES_CACHE_STORE = "generated-schedules-cache";
+
+type GeneratedSchedulesCacheRecord = {
+  key: string;
+  schedules: SavedSection[][];
+  updatedAt: number;
+};
+
 let db: IDBDatabase | null = null;
+let openingDb: Promise<IDBDatabase | null> | null = null;
 
 /**
  * Get connection to the local database
  * */
 export async function getDb() {
-  if (typeof window === "undefined") {
+  if (typeof window === "undefined" || typeof indexedDB === "undefined") {
     return;
   }
 
@@ -12,13 +25,27 @@ export async function getDb() {
     return db;
   }
 
-  const req = indexedDB.open("asf");
+  if (openingDb !== null) {
+    return openingDb;
+  }
 
-  const promise: Promise<IDBDatabase | null> = new Promise((resolve) => {
+  const req = indexedDB.open(DB_NAME, DB_VERSION);
+
+  openingDb = new Promise((resolve) => {
     const t = setTimeout(() => {
       console.error("Opening database timed out");
       resolve(null);
-    }, 1000);
+    }, 5000);
+
+    req.onupgradeneeded = () => {
+      const nextDb = req.result;
+
+      if (!nextDb.objectStoreNames.contains(GENERATED_SCHEDULES_CACHE_STORE)) {
+        nextDb.createObjectStore(GENERATED_SCHEDULES_CACHE_STORE, {
+          keyPath: "key",
+        });
+      }
+    };
 
     req.onsuccess = () => {
       clearTimeout(t);
@@ -32,11 +59,121 @@ export async function getDb() {
     };
   });
 
-  const r = await promise.catch(() => null);
-
-  if (r !== null) {
-    db = r;
-  }
+  db = await openingDb.catch(() => null);
+  openingDb = null;
 
   return db;
+}
+
+function getGeneratedSchedulesStore(
+  database: IDBDatabase,
+  mode: IDBTransactionMode,
+) {
+  if (!database.objectStoreNames.contains(GENERATED_SCHEDULES_CACHE_STORE)) {
+    console.error("Generated schedules cache store does not exist");
+    return null;
+  }
+
+  return database
+    .transaction(GENERATED_SCHEDULES_CACHE_STORE, mode)
+    .objectStore(GENERATED_SCHEDULES_CACHE_STORE);
+}
+
+export async function getGeneratedSchedulesCache(key: string) {
+  const database = await getDb();
+
+  if (!database) {
+    return null;
+  }
+
+  const store = getGeneratedSchedulesStore(database, "readonly");
+
+  if (!store) {
+    return null;
+  }
+
+  return new Promise<SavedSection[][] | null>((resolve) => {
+    const req = store.get(key);
+
+    req.onsuccess = () => {
+      const result = req.result as GeneratedSchedulesCacheRecord | undefined;
+      resolve(result?.schedules ?? null);
+    };
+
+    req.onerror = () => {
+      console.error("Could not read generated schedules cache");
+      resolve(null);
+    };
+  });
+}
+
+export async function setGeneratedSchedulesCache(
+  key: string,
+  schedules: SavedSection[][],
+) {
+  const database = await getDb();
+
+  if (!database) {
+    return false;
+  }
+
+  const store = getGeneratedSchedulesStore(database, "readwrite");
+
+  if (!store) {
+    return false;
+  }
+
+  return new Promise<boolean>((resolve) => {
+    const transaction = store.transaction;
+
+    store.put({
+      key,
+      schedules,
+      updatedAt: Date.now(),
+    } satisfies GeneratedSchedulesCacheRecord);
+
+    transaction.oncomplete = () => resolve(true);
+
+    transaction.onerror = () => {
+      console.error("Could not write generated schedules cache");
+      resolve(false);
+    };
+
+    transaction.onabort = () => {
+      console.error("Writing generated schedules cache was aborted");
+      resolve(false);
+    };
+  });
+}
+
+export async function deleteGeneratedSchedulesCache(key: string) {
+  const database = await getDb();
+
+  if (!database) {
+    return false;
+  }
+
+  const store = getGeneratedSchedulesStore(database, "readwrite");
+
+  if (!store) {
+    return false;
+  }
+
+  return new Promise<boolean>((resolve) => {
+    const transaction = store.transaction;
+
+    store.delete(key);
+
+    transaction.oncomplete = () => resolve(true);
+
+    transaction.onerror = () => {
+      console.error("Could not delete generated schedules cache");
+      resolve(false);
+    };
+
+    transaction.onabort = () => {
+      console.error("Deleting generated schedules cache was aborted");
+      resolve(false);
+    };
+  });
 }

--- a/src/lib/store/db.ts
+++ b/src/lib/store/db.ts
@@ -127,6 +127,11 @@ export async function setGeneratedSchedulesCache(
   return new Promise<boolean>((resolve) => {
     const transaction = store.transaction;
 
+    if (abortSignal?.aborted) {
+      transaction.abort();
+      resolve(false);
+    }
+
     if (abortSignal) {
       abortSignal.onabort = () => transaction.abort();
     }
@@ -169,6 +174,11 @@ export async function deleteGeneratedSchedulesCache(
 
   return new Promise<boolean>((resolve) => {
     const transaction = store.transaction;
+
+    if (abortSignal?.aborted) {
+      transaction.abort();
+      resolve(false);
+    }
 
     if (abortSignal) {
       abortSignal.onabort = () => transaction.abort();

--- a/src/lib/store/db.ts
+++ b/src/lib/store/db.ts
@@ -130,6 +130,7 @@ export async function setGeneratedSchedulesCache(
     if (abortSignal?.aborted) {
       transaction.abort();
       resolve(false);
+      return;
     }
 
     if (abortSignal) {
@@ -178,6 +179,7 @@ export async function deleteGeneratedSchedulesCache(
     if (abortSignal?.aborted) {
       transaction.abort();
       resolve(false);
+      return;
     }
 
     if (abortSignal) {


### PR DESCRIPTION
- added indexed db storage
- caching the generated schedules in indexed db rather than sessionStorage

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist generated schedules in IndexedDB instead of sessionStorage in Autobuild
> - Adds [src/lib/store/db.ts](https://github.com/mingli202/next-schedule-maker/pull/25/files#diff-012f3e90f3ac5c22c9b2d1a02925c7849e59669ec818b36b17848a07fca652a5), a new IndexedDB module that provides `getGeneratedSchedulesCache`, `setGeneratedSchedulesCache`, and `deleteGeneratedSchedulesCache` with `AbortSignal` support and a 5-second open timeout.
> - Replaces direct sessionStorage schedule storage in [Autobuild.tsx](https://github.com/mingli202/next-schedule-maker/pull/25/files#diff-cd29e3b271418a443cbd5bb80d1af9828e61ffe03bfe47edc74787835dd0e524) with an IndexedDB-backed cache; sessionStorage now holds only a unique cache key and `lastScrolledIndex`.
> - On mount, if a cache key exists in sessionStorage, schedules are loaded asynchronously from IndexedDB before rendering results; a `PageLoading` state is shown during this initial load.
> - Adds a schedule count header to the results list in [Results.tsx](https://github.com/mingli202/next-schedule-maker/pull/25/files#diff-053071e30b4816098b1c647ddc60f14157d30ef6843cd979ba91fe36ff1f5f88).
> - Behavioral Change: the PR check workflow now upserts a single bot comment (identified by an HTML marker) instead of posting a new comment on every run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9a05b4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->