### PR TITLE
bring back info

### DIFF
--- a/src/components/root/editor/search/SearchBar.tsx
+++ b/src/components/root/editor/search/SearchBar.tsx
@@ -1,8 +1,10 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
+import { Info } from "lucide-react";
 import { type SubmitEvent, useCallback, useRef } from "react";
 import { Field, FieldLabel } from "src/components/ui/field";
 import { Input } from "src/components/ui/input";
 import { useDebounce } from "src/hooks";
+import { SearchBarInfo } from "./SearchBarInfo";
 
 const activeSearchDelayMili = 200;
 
@@ -41,7 +43,7 @@ export function SearchBar() {
 
   return (
     <form onSubmit={handleSubmit} autoComplete="off" ref={formRef}>
-      <Field>
+      <Field orientation="horizontal">
         <FieldLabel htmlFor="search" className="hidden">
           search
         </FieldLabel>
@@ -54,6 +56,7 @@ export function SearchBar() {
           onChange={handleChange}
           defaultValue={q}
         />
+        <SearchBarInfo />
       </Field>
     </form>
   );

--- a/src/components/root/editor/search/SearchBar.tsx
+++ b/src/components/root/editor/search/SearchBar.tsx
@@ -1,5 +1,4 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { Info } from "lucide-react";
 import { type SubmitEvent, useCallback, useRef } from "react";
 import { Field, FieldLabel } from "src/components/ui/field";
 import { Input } from "src/components/ui/input";

--- a/src/components/root/editor/search/SearchBarInfo.tsx
+++ b/src/components/root/editor/search/SearchBarInfo.tsx
@@ -1,0 +1,45 @@
+import { Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "src/components/ui/tooltip";
+import { cn } from "src/lib/utils";
+
+export function SearchBarInfo() {
+  return (
+    <Tooltip delayDuration={0}>
+      <div className={cn("group relative flex cursor-default font-bold")}>
+        <TooltipTrigger asChild>
+          <Info className="h-5 w-5" />
+        </TooltipTrigger>
+        <TooltipContent className="flex w-md flex-col gap-2 p-2 text-sm font-normal shadow-lg">
+          <p>
+            It will attempt to search for what you meant to search by matching
+            various patterns:
+          </p>
+          <ul className="list-disc pl-4">
+            <li>{"r>, r<, r="} matches a rating range.</li>
+            <li>{"s>, s<, s="} matches a score range.</li>
+            <li>
+              M, T, W, R, F or any combinasion of these letters will match days
+              off.
+            </li>
+            <li>
+              Any combinasion of NN:MM, NNhMM, NNMM with either a dash or{" "}
+              {'"to"'} between matches a time range.
+            </li>
+            <li>ALL CAPS matches a course name.</li>
+            <li>NNN Three numbers matches a code.</li>
+            <li>{'"honours" and "blended"'} are special keywords.</li>
+            <li>
+              Matches a teacher{"'"}s name if the keyword matches at least 67%
+              of either their first or last name.
+            </li>
+            <li>Will look for class titles if none of the above matches.</li>
+          </ul>
+        </TooltipContent>
+      </div>
+    </Tooltip>
+  );
+}

--- a/src/components/root/editor/search/SearchBarInfo.tsx
+++ b/src/components/root/editor/search/SearchBarInfo.tsx
@@ -4,12 +4,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "src/components/ui/tooltip";
-import { cn } from "src/lib/utils";
 
 export function SearchBarInfo() {
   return (
     <Tooltip delayDuration={0}>
-      <div className={cn("group relative flex cursor-default font-bold")}>
+      <div className="relative flex cursor-default font-bold">
         <TooltipTrigger asChild>
           <Info className="h-5 w-5" />
         </TooltipTrigger>

--- a/src/components/root/editor/search/SearchBarInfo.tsx
+++ b/src/components/root/editor/search/SearchBarInfo.tsx
@@ -21,7 +21,7 @@ export function SearchBarInfo() {
             <li>{"r>, r<, r="} matches a rating range.</li>
             <li>{"s>, s<, s="} matches a score range.</li>
             <li>
-              M, T, W, R, F or any combinasion of these letters will match days
+              M, T, W, R, F or any combination of these letters will match days
               off.
             </li>
             <li>


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Restore search bar info tooltip with supported search pattern guidance
Re-adds a `SearchBarInfo` component to the search bar that shows an info icon with a tooltip listing supported search patterns (rating/score ranges, day codes, time formats, course name formats, keywords, and fuzzy teacher name matching). The field layout in [SearchBar.tsx](https://github.com/mingli202/next-schedule-maker/pull/31/files#diff-2956f54bb260cdc695c7f0ce492f819967db28b9aa64b2fa204253ecdbc7be4d) is updated to `orientation="horizontal"` to accommodate the new icon.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized e436ac4.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->