### PR TITLE
fix styling

### DIFF
--- a/src/components/root/editor/ReleaseNotes.tsx
+++ b/src/components/root/editor/ReleaseNotes.tsx
@@ -98,31 +98,31 @@ export default function ReleaseNotes() {
           onClick={handleClick}
         >
           <div
-            className="border-primary bg-background flex w-[min(35rem,80%)] flex-col gap-2 rounded-md border-4 border-solid p-2 md:gap-4 md:p-4"
+            className="border-primary bg-background flex max-h-9/10 w-[min(35rem,80%)] flex-col gap-2 rounded-md border-4 border-solid p-2 md:gap-4 md:p-4"
             ref={popupRef}
           >
-            <div>
-              <div className="flex items-center justify-between gap-2 text-xl md:text-2xl">
-                <h1>What{"'"}s new in Fall 2026</h1>
-                <Button variant="basic" className="p-0" onClick={close}>
-                  <X className="h-5 w-5 md:h-6 md:w-6" />
-                </Button>
-              </div>
+            <div className="flex items-center justify-between gap-2 text-xl md:text-2xl">
+              <h1>What{"'"}s new in Fall 2026</h1>
+              <Button variant="basic" className="p-0" onClick={close}>
+                <X className="h-5 w-5 md:h-6 md:w-6" />
+              </Button>
             </div>
 
-            {versionHistory.map(([version, details]) => (
-              <ul
-                className="bg-secondary/50 list-outside list-disc rounded-sm p-2 [&>li]:ml-6"
-                key={version}
-              >
-                <p>
-                  {version} {currentVersion === version ? "(Latest)" : null}
-                </p>
-                {details.map((detail, i) => (
-                  <li key={i.toString() + detail}>{detail}</li>
-                ))}
-              </ul>
-            ))}
+            <div className="flex flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto">
+              {versionHistory.map(([version, details]) => (
+                <ul
+                  className="bg-secondary/50 shrink-0 list-outside list-disc rounded-sm p-2 [&>li]:ml-6"
+                  key={version}
+                >
+                  <p>
+                    {version} {currentVersion === version ? "(Latest)" : null}
+                  </p>
+                  {details.map((detail, i) => (
+                    <li key={i.toString() + detail}>{detail}</li>
+                  ))}
+                </ul>
+              ))}
+            </div>
           </div>
         </motion.div>
       )}


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix scrolling and layout overflow in the `ReleaseNotes` modal
Adds `max-h-9/10` to the modal container and wraps the version list in a scrollable flex column (`overflow-y-auto`) so the popup no longer overflows the viewport when content is tall. Also removes a redundant wrapper div from the header and adds `shrink-0` to each version list item to preserve layout.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 04756cc.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->