### PR TITLE
fix: weird hover preview

### DIFF
--- a/src/components/root/editor/search/SearchResult.tsx
+++ b/src/components/root/editor/search/SearchResult.tsx
@@ -157,13 +157,31 @@ const MemoizedSectionCard = memo(
     index: number;
     section: Section;
   }) => {
+    const mouseOver = useRef(false);
+
     return (
       <div className={cn(index !== 0 && "pt-2")}>
         <SectionCard
           section={section}
           footer={<SectionCardFooter sectionId={section.id} />}
-          onMouseEnter={() => onHover(section.id)}
-          onMouseLeave={() => onHover("none")}
+          onMouseEnter={() => {
+            if (mouseOver.current) {
+              return;
+            }
+            mouseOver.current = true;
+            return onHover(section.id);
+          }}
+          onMouseOver={() => {
+            if (mouseOver.current) {
+              return;
+            }
+            mouseOver.current = true;
+            return onHover(section.id);
+          }}
+          onMouseLeave={() => {
+            mouseOver.current = false;
+            return onHover("none");
+          }}
         />
       </div>
     );

--- a/src/hooks/useSectionInSearchHelper.ts
+++ b/src/hooks/useSectionInSearchHelper.ts
@@ -53,6 +53,8 @@ export function useSectionInSearchHelper(sectionId: string) {
               colorIndex: getNextAvailableColorIndex(prev.sections),
             },
           ],
+          previewSectionId:
+            prev.previewSectionId === undefined ? undefined : "none",
         }),
       });
     }


### PR DESCRIPTION
When having checked filter out invalid sections and you've added the last valid section with preview hover on, then a ghost of the preview will still be there even the user isn't hovering above anything.

Also, when the cursor spawns on a section card, then the onMouseEnter doesn't trigger, so listen for a onMouseOver with a flag that prevents from rerendering on mousemove

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix hover preview firing multiple times in search results
> - Adds a `mouseOver` ref in [`SearchResult.tsx`](https://github.com/mingli202/next-schedule-maker/pull/34/files#diff-e152bf3a6fa6c155a53e3312e7b534c9a64e16f649fd8eaa420d132ed73564d7) to guard `onHover` so it fires only once per hover session, preventing repeated calls from cascading `mouseenter`/`mouseover` events.
> - Clears `previewSectionId` to `"none"` when adding a section in [`useSectionInSearchHelper.ts`](https://github.com/mingli202/next-schedule-maker/pull/34/files#diff-e2b39ac87b1720fb3e94fccf511a0352eacb8a96976da00315df40f7a8222a15), unless it was previously `undefined`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acc5dcb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->