### PR TITLE
feat: Status footer

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -11,11 +11,18 @@ import {
   useRef,
   useState,
 } from "react";
+import type { RecordValues } from "src/types";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
+export const ButtonVariant = {
+  Basic: "basic",
+  Special: "special",
+} as const;
+export type ButtonVariant = RecordValues<typeof ButtonVariant>;
+
 type Props = {
-  variant?: "basic" | "special";
+  variant?: ButtonVariant;
 } & {
   disableBgEffect?: boolean;
   disableScaleEffect?: boolean;

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -31,7 +31,7 @@ function View({
     <div
       className={cn(
         "relative box-border grid w-full",
-        "bg-primary text-primary-foreground p-2",
+        "bg-primary text-primary-foreground p-2 md:p-4",
 
         disableControls
           ? "h-full grid-cols-5 grid-rows-[repeat(20,1fr)] md:h-full md:w-full md:p-2"

--- a/src/components/View/View.tsx
+++ b/src/components/View/View.tsx
@@ -31,7 +31,7 @@ function View({
     <div
       className={cn(
         "relative box-border grid w-full",
-        "bg-primary text-primary-foreground rounded-md p-2 md:p-4",
+        "bg-primary text-primary-foreground p-2",
 
         disableControls
           ? "h-full grid-cols-5 grid-rows-[repeat(20,1fr)] md:h-full md:w-full md:p-2"
@@ -43,9 +43,6 @@ function View({
     >
       {!disableControls && (
         <>
-          <p className="absolute top-0 left-0 col-span-1 row-span-1 p-2 text-[0.5rem] md:text-xs">
-            Fall 2026 (June 5 pdf)
-          </p>
           <div className="grid-rows-[repeat(20,1fr) col-span-1 row-[span_21/span_21] mr-4 grid grid-cols-1">
             <Hours />
           </div>

--- a/src/components/root/editor/StatusFooter.tsx
+++ b/src/components/root/editor/StatusFooter.tsx
@@ -1,23 +1,41 @@
+import { Link } from "@tanstack/react-router";
 import { useConvexAuth } from "convex/react";
+import { getAuth, signOut } from "firebase/auth";
+import { useCallback } from "react";
 import { Button } from "src/components";
 import { ButtonVariant } from "src/components/Button";
+import { app } from "src/integrations/firebase";
 import { useSectionStore } from "src/lib/store/section";
 
 export function StatusFooter() {
   const store = useSectionStore();
   const { isLoading, isAuthenticated } = useConvexAuth();
 
+  const logOut = useCallback(async () => {
+    const auth = getAuth(app);
+    await signOut(auth);
+  }, []);
+
   return (
     <div className="bg-secondary/50 flex items-center justify-between text-xs">
       <div>
         {isLoading ? null : isAuthenticated ? (
-          <Button className="rounded-none py-1" variant={ButtonVariant.Special}>
-            Account
+          <Button
+            className="rounded-none py-1"
+            variant={ButtonVariant.Special}
+            onClick={logOut}
+          >
+            Log out
           </Button>
         ) : (
-          <Button className="rounded-none py-1" variant={ButtonVariant.Special}>
-            Log in
-          </Button>
+          <Link to="/login">
+            <Button
+              className="rounded-none py-1"
+              variant={ButtonVariant.Special}
+            >
+              Log in
+            </Button>
+          </Link>
         )}
       </div>
       <p className="flex gap-1">

--- a/src/components/root/editor/StatusFooter.tsx
+++ b/src/components/root/editor/StatusFooter.tsx
@@ -1,0 +1,29 @@
+import { useConvexAuth } from "convex/react";
+import { Button } from "src/components";
+import { ButtonVariant } from "src/components/Button";
+import { useSectionStore } from "src/lib/store/section";
+
+export function StatusFooter() {
+  const store = useSectionStore();
+  const { isLoading, isAuthenticated } = useConvexAuth();
+
+  return (
+    <div className="bg-secondary/50 flex items-center justify-between text-xs">
+      <div>
+        {isLoading ? null : isAuthenticated ? (
+          <Button className="rounded-none py-1" variant={ButtonVariant.Special}>
+            Account
+          </Button>
+        ) : (
+          <Button className="rounded-none py-1" variant={ButtonVariant.Special}>
+            Log in
+          </Button>
+        )}
+      </div>
+      <p className="flex gap-1">
+        {store.semester}
+        <span className="hidden md:block"> ({store.filename})</span>
+      </p>
+    </div>
+  );
+}

--- a/src/components/root/editor/StatusFooter.tsx
+++ b/src/components/root/editor/StatusFooter.tsx
@@ -1,7 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { useConvexAuth } from "convex/react";
 import { signOut } from "firebase/auth";
-import { useCallback } from "react";
 import { Button } from "src/components";
 import { ButtonVariant } from "src/components/Button";
 import { getAuth } from "src/integrations/firebase";
@@ -13,10 +12,6 @@ export function StatusFooter() {
   const store = useSectionStore();
   const { isLoading, isAuthenticated } = useConvexAuth();
 
-  const logOut = useCallback(async () => {
-    await signOut(auth);
-  }, []);
-
   return (
     <div className="bg-secondary/50 flex items-center justify-between text-xs">
       <div>
@@ -24,7 +19,7 @@ export function StatusFooter() {
           <Button
             className="rounded-none py-1"
             variant={ButtonVariant.Special}
-            onClick={logOut}
+            onClick={() => signOut(auth)}
           >
             Log out
           </Button>

--- a/src/components/root/editor/StatusFooter.tsx
+++ b/src/components/root/editor/StatusFooter.tsx
@@ -1,18 +1,19 @@
 import { Link } from "@tanstack/react-router";
 import { useConvexAuth } from "convex/react";
-import { getAuth, signOut } from "firebase/auth";
+import { signOut } from "firebase/auth";
 import { useCallback } from "react";
 import { Button } from "src/components";
 import { ButtonVariant } from "src/components/Button";
-import { app } from "src/integrations/firebase";
+import { getAuth } from "src/integrations/firebase";
 import { useSectionStore } from "src/lib/store/section";
+
+const auth = getAuth();
 
 export function StatusFooter() {
   const store = useSectionStore();
   const { isLoading, isAuthenticated } = useConvexAuth();
 
   const logOut = useCallback(async () => {
-    const auth = getAuth(app);
     await signOut(auth);
   }, []);
 

--- a/src/components/root/editor/index.ts
+++ b/src/components/root/editor/index.ts
@@ -1,2 +1,3 @@
-export * from "./SidePane";
 export * from "./DragIndicator";
+export * from "./SidePane";
+export * from "./StatusFooter";

--- a/src/components/root/editor/search/SearchResult.tsx
+++ b/src/components/root/editor/search/SearchResult.tsx
@@ -177,7 +177,6 @@ const MemoizedSectionCard = memo(
         <SectionCard
           section={section}
           footer={<SectionCardFooter sectionId={section.id} />}
-          onMouseEnter={onMouseOver}
           onMouseOver={onMouseOver}
           onMouseLeave={onMouseLeave}
         />

--- a/src/lib/schedule/filterDown.spec.ts
+++ b/src/lib/schedule/filterDown.spec.ts
@@ -156,6 +156,12 @@ const store: SectionStore = {
       .filter((prof) => prof.trim() !== ""),
   ),
   codes: new Set(sections.map((section) => section.code)),
+  filename: "",
+  sectionsDiff: {
+    previousSectionsChanged: [],
+    sectionsAdded: [],
+    sectionsRemoved: [],
+  },
 };
 
 const filterDown = (sectionStore: SectionStore, search: SearchSectionParams) =>

--- a/src/lib/store/section.ts
+++ b/src/lib/store/section.ts
@@ -1,7 +1,7 @@
 import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
 import type { SectionByIdSchema, SectionStore } from "src/types";
 import { type DataVersionCommit, LatestVersionCommit } from "src/types/enums";
-import { GlobalAllSections } from "src/types/generated";
+import { GlobalAllSections, type SectionsDiff } from "src/types/generated";
 
 export const allSectionsQueryOptions = (
   commit: DataVersionCommit = LatestVersionCommit,
@@ -28,12 +28,21 @@ export async function fetchStore(
 
   let sectionsMap: SectionByIdSchema = {};
   let semester = "";
+  let filename = "";
+  let sectionsDiff: SectionsDiff = {
+    previousSectionsChanged: [],
+    sectionsAdded: [],
+    sectionsRemoved: [],
+  };
 
   if (res.ok) {
     try {
       const json = await res.json();
       const globalAllSections = GlobalAllSections.parse(json);
+
       semester = globalAllSections.semester;
+      filename = globalAllSections.filename;
+      sectionsDiff = globalAllSections.sectionsDiff;
       sectionsMap = globalAllSections.sectionsById;
     } catch (e) {
       console.error("Failed to parse sections data: ", e);
@@ -60,6 +69,8 @@ export async function fetchStore(
 
   return {
     semester,
+    filename,
+    sectionsDiff,
     sectionsById,
     professors,
     codes,

--- a/src/routes/editor/route.tsx
+++ b/src/routes/editor/route.tsx
@@ -1,7 +1,11 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { type ComponentProps, useCallback, useRef } from "react";
 import { View } from "src/components";
-import { DragIndicator, SidePane } from "src/components/root/editor";
+import {
+  DragIndicator,
+  SidePane,
+  StatusFooter,
+} from "src/components/root/editor";
 import ReleaseNotes from "src/components/root/editor/ReleaseNotes";
 import { EditorInViewParams } from "@/types/schedule";
 
@@ -34,22 +38,22 @@ function RouteComponent() {
   }, []);
 
   return (
-    <div className="text-text relative box-border flex w-screen overflow-hidden p-2 text-sm max-md:flex-col md:h-dvh md:text-base">
-      <SidePane
-        className="min-h-0 max-w-dvh max-md:h-screen md:basis-1/3"
-        ref={menuRef}
-      />
-      <DragIndicator onNewXPos={onNewXPost} />
-      <ViewWrapper
-        className="min-h-0 max-md:h-[70dvh] md:basis-2/3"
-        ref={viewRef}
-      />
-      <ReleaseNotes />
+    <div className="relative flex w-screen flex-col overflow-hidden text-sm md:h-screen md:text-base">
+      <div className="flex max-md:flex-col md:flex-1">
+        <SidePane
+          className="max-w-dvh p-2 max-md:h-[93vh] md:basis-1/3"
+          ref={menuRef}
+        />
+        <DragIndicator onNewXPos={onNewXPost} />
+        <ViewWrapper className="max-md:h-[70vh] md:basis-2/3" ref={viewRef} />
+        <ReleaseNotes />
+      </div>
+      <StatusFooter />
     </div>
   );
 }
 
-function ViewWrapper(props: ComponentProps<"div">) {
+function ViewWrapper({ ...props }: ComponentProps<"div">) {
   const sections = Route.useSearch({ select: (s) => s.sections });
   const navigate = useNavigate();
 

--- a/src/routes/forgot/route.tsx
+++ b/src/routes/forgot/route.tsx
@@ -53,7 +53,7 @@ function RouteComponent() {
         </Field>
       </form>
 
-      <Link to="/login" className="hover:underline">
+      <Link to="/login" className="hover:underline" replace>
         Back to sign in
       </Link>
     </div>

--- a/src/routes/login/route.tsx
+++ b/src/routes/login/route.tsx
@@ -130,6 +130,7 @@ function RouteComponent() {
                   <Link
                     to="/forgot"
                     className="text-sm opacity-50 transition hover:opacity-100"
+                    replace
                   >
                     Forgot?
                   </Link>

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,7 +1,7 @@
 import type { RecordValues } from "@/types";
 
 export const DataVersionCommit = {
-  Fall2026: "223da53964cb95211c69e6d1183ea14c1555371a",
+  Fall2026: "8394a819ab28d04e3c89e020338a1848a0f96775",
 } as const;
 export const LatestVersionCommit = DataVersionCommit.Fall2026;
 

--- a/src/types/generated.ts
+++ b/src/types/generated.ts
@@ -60,8 +60,17 @@ export const Section = z.object({
 });
 export type Section = z.infer<typeof Section>;
 
+export const SectionsDiff = z.object({
+	previousSectionsChanged: z.array(Section),
+	sectionsAdded: z.array(z.string()),
+	sectionsRemoved: z.array(Section),
+});
+export type SectionsDiff = z.infer<typeof SectionsDiff>;
+
 export const GlobalAllSections = z.object({
 	semester: z.string(),
 	sectionsById: z.record(z.string(), Section),
+	filename: z.string(),
+	sectionsDiff: SectionsDiff,
 });
 export type GlobalAllSections = z.infer<typeof GlobalAllSections>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { z } from "zod";
 import type { DataVersionCommit } from "./enums";
-import { Section } from "./generated";
+import { Section, type SectionsDiff } from "./generated";
 
 export type RecordValues<T extends Record<string | number | symbol, unknown>> =
   T[keyof T];
@@ -15,6 +15,8 @@ export type SectionByIdSchema = z.infer<typeof SectionByIdSchema>;
 
 export type SectionStore = {
   readonly semester: string;
+  readonly filename: string;
+  readonly sectionsDiff: SectionsDiff;
   readonly sectionsById: Map<string, Section>;
   readonly professors: Set<string>;
   readonly codes: Set<string>;


### PR DESCRIPTION
- Have a status footer at the bottom
- Updated generated API to the latest json shape

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add status footer to editor page with login/logout controls and semester info
> - Adds a new [`StatusFooter`](https://github.com/mingli202/next-schedule-maker/pull/35/files#diff-5a4b815cd1bda0f9daca799b946fb1642e0b102a914cdf7142a9511592bb1637) component to the editor page that shows the current semester and filename from the section store, plus a logout button when authenticated or a login link when not.
> - Extends [`SectionStore`](https://github.com/mingli202/next-schedule-maker/pull/35/files#diff-a9ba9cbedd19c9f66d564d2e89912890209b98f0a7ef19187877d2587300e476) and [`GlobalAllSections`](https://github.com/mingli202/next-schedule-maker/pull/35/files#diff-765ab3876c2d3322cabe751ad8e517c046daa2e7a1ff8eaff7a4e910f944d530) with `filename` and `sectionsDiff` fields, populated from the remote JSON fetch in [`fetchStore`](https://github.com/mingli202/next-schedule-maker/pull/35/files#diff-7d6db622786def6e37c7a6eafed7f5c2d503bb3c63b4be8e46b42ee05a42679a).
> - Reworks the editor layout in [`route.tsx`](https://github.com/mingli202/next-schedule-maker/pull/35/files#diff-df75be35c0fe1603975b57f750656fd72160f70399c589da64c5e72623e39e73) to use a flex column container, placing the footer below the main content with updated responsive sizing for `SidePane` and `View`.
> - Updates the `Fall2026` commit hash in [`DataVersionCommit`](https://github.com/mingli202/next-schedule-maker/pull/35/files#diff-c11b94ab4abb4e89a897c1aa5ab7db811cafb3a6853ba5825c6518d13ef25fae) and removes the hardcoded label text from the [`View`](https://github.com/mingli202/next-schedule-maker/pull/35/files#diff-fb4d60074b2cc7aa9578bc7a0a68fa402100f2c5227605dd993785e3dd4b158b) component.
> - Behavioral Change: `SidePane`/`View` height and padding values change at all breakpoints due to the layout rework.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5853264.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->